### PR TITLE
update vps

### DIFF
--- a/examples/basic/pages/+Layout.ts
+++ b/examples/basic/pages/+Layout.ts
@@ -1,4 +1,0 @@
-// Default Layout (can be overriden by pages)
-import { default as Layout } from "../layouts/LayoutDefault";
-
-export default Layout;

--- a/examples/basic/pages/+config.ts
+++ b/examples/basic/pages/+config.ts
@@ -1,7 +1,10 @@
 import type { Config } from "solide";
+import Layout from '../layouts/LayoutDefault'
 
 // Default config (can be overriden by pages)
 export default {
+  // @ts-expect-error
+  Layout,
   // <title>
   title: "My Solide App",
   // <meta name="description">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,11 +39,11 @@ importers:
       typescript: ^5.0.2
       vite: ^4.2.1
       vite-plugin-solid: ^2.6.1
-      vite-plugin-ssr: ^0.4.106
+      vite-plugin-ssr: ^0.4.108
     dependencies:
       vite: 4.2.1_@types+node@18.15.10
       vite-plugin-solid: 2.6.1_solid-js@1.6.16+vite@4.2.1
-      vite-plugin-ssr: 0.4.106_vite@4.2.1
+      vite-plugin-ssr: 0.4.108_vite@4.2.1
     devDependencies:
       '@babel/core': 7.21.3
       '@babel/preset-env': 7.20.2_@babel+core@7.21.3
@@ -1591,6 +1591,12 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
   /ansi-styles/3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -2238,8 +2244,8 @@ packages:
       - supports-color
     dev: false
 
-  /vite-plugin-ssr/0.4.106_vite@4.2.1:
-    resolution: {integrity: sha512-HAXRK4KKTGtuE4l4KML3ZdJbev779Z3MYDTqDCrXOkSXQOciA44dOYXPyOKQqRvf+xRHvPnmwaDZVncVHixtww==}
+  /vite-plugin-ssr/0.4.108_vite@4.2.1:
+    resolution: {integrity: sha512-WaKbwafwtBSy5EBG4u02qPNzr0VcSAPzm4wvBCInLFlBDUZ25IL4ARev+OhkM3thqdPrECtb+FBB7CMbJDT5mA==}
     engines: {node: '>=12.19.0'}
     hasBin: true
     peerDependencies:
@@ -2252,6 +2258,7 @@ packages:
       '@brillout/import': 0.2.2
       '@brillout/json-serializer': 0.5.3
       '@brillout/vite-plugin-import-build': 0.2.13
+      acorn: 8.8.2
       cac: 6.7.14
       es-module-lexer: 0.10.5
       esbuild: 0.17.14

--- a/solide/package.json
+++ b/solide/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "vite": "^4.2.1",
     "vite-plugin-solid": "^2.6.1",
-    "vite-plugin-ssr": "^0.4.106"
+    "vite-plugin-ssr": "^0.4.108"
   },
   "scripts": {
     "dev": "rollup -c rollup.config.js --watch",

--- a/solide/renderer/+onRenderHtml.tsx
+++ b/solide/renderer/+onRenderHtml.tsx
@@ -18,12 +18,12 @@ async function onRenderHtml(pageContext: PageContextServer) {
   const title = getTitle(pageContext);
   const titleTag = !title ? "" : escapeInject`<title>${title}</title>`;
 
-  const { description } = pageContext.exports;
+  const { description } = pageContext.config;
   const descriptionTag = !description
     ? ""
     : escapeInject`<meta name="description" content="${description}" />`;
 
-  const Head = pageContext.exports.Head || (() => <></>);
+  const Head = pageContext.config.Head || (() => <></>);
   const headHtml = renderToString(() => (
     <PageContextProvider pageContext={pageContext}>
       <Head />
@@ -34,7 +34,7 @@ async function onRenderHtml(pageContext: PageContextServer) {
   // const asString = renderToString(() => page);
   stampPipe(pipe, "node-stream");
 
-  const lang = pageContext.exports.lang || "en";
+  const lang = pageContext.config.lang || "en";
 
   const documentHtml = escapeInject`<!DOCTYPE html>
     <html lang='${lang}'>

--- a/solide/renderer/getPageElement.tsx
+++ b/solide/renderer/getPageElement.tsx
@@ -5,8 +5,8 @@ import { PageContextProvider } from "./PageContextProvider";
 import type { JSX } from "solid-js";
 
 function getPageElement(pageContext: PageContext): JSX.Element {
-  const Layout = pageContext.exports.Layout ?? PassThrough;
-  const Wrapper = pageContext.exports.Wrapper ?? PassThrough;
+  const Layout = pageContext.config.Layout ?? PassThrough;
+  const Wrapper = pageContext.config.Wrapper ?? PassThrough;
   const { Page, pageProps } = pageContext;
   const page = (
     <PageContextProvider pageContext={pageContext}>

--- a/solide/renderer/getTitle.ts
+++ b/solide/renderer/getTitle.ts
@@ -4,8 +4,8 @@ import { isCallable } from "./utils/isCallable";
 
 function getTitle(pageContext: {
   title?: unknown;
-  exports: Record<string, unknown>;
-  exportsAll: Record<string, undefined | { filePath: string }[]>;
+  config: Record<string, unknown>;
+  configList: Record<string, undefined | { configOrigin: string }[]>;
 }): null | string {
   if (typeof pageContext.title === "string") {
     return pageContext.title;
@@ -13,25 +13,25 @@ function getTitle(pageContext: {
   if (pageContext.title) {
     throw new Error("pageContext.title should be a string");
   }
-  const { title } = pageContext.exports;
+  const { title } = pageContext.config;
   if (typeof title === "string") {
     return title;
   }
   if (!title) {
     return null;
   }
-  const { filePath } = pageContext.exportsAll.title![0]!;
+  const { configOrigin } = pageContext.configList.title![0]!;
   if (isCallable(title)) {
     const val = title(pageContext);
     if (typeof val === "string") {
       return val;
     }
     if (val) {
-      throw new Error(filePath + " `export { title }` should return a string");
+      throw new Error(configOrigin + " `export { title }` should return a string");
     }
   }
   throw new Error(
-    filePath +
+    configOrigin +
       " `export { title }` should be a string or a function returning a string"
   );
 }

--- a/solide/renderer/types.ts
+++ b/solide/renderer/types.ts
@@ -19,7 +19,7 @@ type WrapperComponent = ({ children }: { children: any }) => JSX.Element;
 export type PageContextCommon = {
   Page: Page;
   pageProps?: PageProps;
-  exports: {
+  config: {
     Layout?: WrapperComponent;
     Wrapper?: WrapperComponent;
   };
@@ -27,7 +27,7 @@ export type PageContextCommon = {
 
 type PageContextServer = PageContextBuiltIn<Page> &
   PageContextCommon & {
-    exports: Partial<SolideConfig>;
+    config: Partial<SolideConfig>;
   };
 type PageContextClient = PageContextBuiltInClient<Page> & PageContextCommon;
 type PageContext = PageContextClient | PageContextServer;


### PR DESCRIPTION
Updating to the latest VPS release which now supports https://vite-plugin-ssr.com/config-code-splitting and `pageContext.config` (to better match the naming of the V1 design).

Does Solid has an assignable component type? To get rid of the `@ts-expect-error`.

When navigating between pages, the VPS logo on the left of the page flickers. Is that an expected behavior with Solid?